### PR TITLE
Add mention name to the resource requestion message

### DIFF
--- a/scripts/staging.coffee
+++ b/scripts/staging.coffee
@@ -74,7 +74,7 @@ module.exports = (robot) ->
     if robot.brain.data.resources[resource]
       resourceOwner = getResourceOwner(robot.brain.data.users, resource)
       if resourceOwner
-        msg.send "#{resourceOwner.name} has #{resource}"
+        msg.send "#{resourceOwner.name} (@#{resourceOwner.mention_name}) has #{resource}"
       else
         msg.send "No one has told me they have #{resource}."
       resourceBackup = getResourceBackup(robot.brain.data.users, resource)


### PR DESCRIPTION
# GET SOME!

Adds a mention name to a resource request, e.g. `Can i have staging?`, so that the owner is notified. 

No way of testing since Chris revels in being the gatekeeper of the zozibot heroku. :trollface: 
