### PR TITLE
Remove @evan from conflicting names comment

### DIFF
--- a/scripts/conflicting_names.coffee
+++ b/scripts/conflicting_names.coffee
@@ -8,7 +8,7 @@
 #   None
 #
 # Commands:
-#   hubot listens for @adam or @evan names and responds.
+#   hubot listens for @adam names and responds.
 #
 # Author:
 #   radixhound


### PR DESCRIPTION
When you type `@rickbot help` it incorrectly says that `@evan` is a conflicting name, when in fact it is not.  As a result, Evan Hourigan gets pinged because `@rickbot help` causes a name mention.